### PR TITLE
添加合并依赖模块id正则表达式过滤配置项。

### DIFF
--- a/lib/processor/module-compiler.js
+++ b/lib/processor/module-compiler.js
@@ -61,6 +61,10 @@ ModuleCompiler.prototype.process = function ( file, processContext, callback ) {
             return;
         }
 
+        // 把idPattern 转化成regex，在合并dependencies之前进行检测
+        if (combine && combine.depIdPattern) {
+            combine.depIdPattern = new RegExp(combine.depIdPattern);
+        }
         var moduleCode = require( '../util/compile-module' )( 
             fileInfo.data, 
             modId, 

--- a/lib/util/compile-module.js
+++ b/lib/util/compile-module.js
@@ -102,15 +102,17 @@ function compileModule(code, moduleId, moduleConfig, combine, excludeModules) {
                 depId, 
                 moduleConfig
             );
-            
-            if ( !excludeModules[ depId ] && fs.existsSync( depFile ) ) {
+
+            if ( (!combine.depIdPattern || combine.depIdPattern.test(depId))
+                && !excludeModules[ depId ] 
+                && fs.existsSync( depFile ) ) {
                 var depMainId = null;
 
                 codes.push( compileModule( 
                     fs.readFileSync( depFile, 'UTF-8' ),
                     depId,
                     moduleConfig, 
-                    true, 
+                    { depIdPattern: combine.depIdPattern }, 
                     excludeModules
                 ) );
             }


### PR DESCRIPTION
我在做build的时候添加了一个正则表达式选项，可以通过它来过滤依赖模块的ID。

Added regex pattern to filter dependencies.
