### PR TITLE
html2js-compiler功能升级

### DIFF
--- a/lib/processor/html2js-compiler.js
+++ b/lib/processor/html2js-compiler.js
@@ -107,9 +107,8 @@ function compileHtml2Js( code, options ) {
 
     var opt = {
         wrap: true,
-        mode: options.mode
+        mode: 'compress'
     };
-
     return require('html2js')(code, opt);
 }
 


### PR DESCRIPTION
build的时候将 `*.tpl` 直接压缩以提高压缩比。

代码中的 this.mode 没有初始化，一直都是 `undefined`，直接设置为 `compress` 即可。
