### PR TITLE
修复md5renamer在处理url时忽略了hash部分引起的bug

### DIFF
--- a/lib/processor/md5-renamer.js
+++ b/lib/processor/md5-renamer.js
@@ -178,6 +178,7 @@ function replaceResPath( value, replaceOption, processor, processContext ) {
 
     var url = require('url').parse(value);
     var search = url.search;
+    var hash = url.hash;
     var resPath = url.pathname;
 
     var lookupPaths = replaceOption.paths;
@@ -207,7 +208,7 @@ function replaceResPath( value, replaceOption, processor, processContext ) {
                 lookupFileInfo.set( 'md5renamed', 1 );
             }
 
-            return md5path + (search || '');
+            return md5path + (search || '') + (hash || '');
         }
         else {
             edp.log.warn( 'No such file or directory %s', lookupFile );


### PR DESCRIPTION
参见 https://github.com/ecomfe/edp/issues/293
