### PR TITLE
process.nextTick 替代 setTimeout

### DIFF
--- a/lib/processor/abstract.js
+++ b/lib/processor/abstract.js
@@ -152,7 +152,7 @@ AbstractProcessor.prototype.processAll = function ( processContext, callback ) {
         function processFinished() { 
             edp.log.write('%s[%s/%s]: %s (%sms)', beforeLog, fileIndex, fileCount, file.path,
                 Date.now() - start );
-            setTimeout( nextFile, 1 );
+            process.nextTick( nextFile );
         }
 
         processor.process(


### PR DESCRIPTION
性能获得提升，以dsp的build为例，all done时间从原来的54253ms提升到43011ms
