### PR TITLE
在less编辑时添加filename参数以支持自定义paths参数

### DIFF
--- a/lib/processor/less-compiler.js
+++ b/lib/processor/less-compiler.js
@@ -65,6 +65,7 @@ LessCompiler.prototype.process = function ( file, processContext, callback ) {
     var parserOptions = edp.util.extend(
         {},
         {
+            filename: file.path,
             paths: [ require( 'path' ).dirname( file.fullPath ) ],
             relativeUrls: true,
             compress: true
@@ -103,7 +104,7 @@ LessCompiler.prototype.process = function ( file, processContext, callback ) {
 
 /**
  * 构建处理后的行为，替换page和js里对less资源的引用
- * 
+ *
  * @param {ProcessContext} processContext 构建环境对象
  */
 LessCompiler.prototype.afterAll = function ( processContext ) {


### PR DESCRIPTION
在less的编译参数中自定义了多个`paths`，如果不指定filename会编辑出错。添加此参数对无`paths`参数的配置无影响。
