### PR TITLE
新增文件内容直接站位替换

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ function injectProcessor( conf ) {
             ReplaceDebug        : require( './lib/processor/replace-debug' ),
             TplMerge            : require( './lib/processor/tpl-merge' ),
             StringReplace       : require( './lib/processor/string-replace' ),
+            SourceProcessor     : require( './lib/processor/source-combine' ),
             BcsUploader         : require( './lib/processor/bcs-uploader' ),
             OutputCleaner       : require( './lib/processor/output-cleaner' )
         } );

--- a/lib/processor/html2js-compiler.js
+++ b/lib/processor/html2js-compiler.js
@@ -107,7 +107,7 @@ function compileHtml2Js( code, options ) {
 
     var opt = {
         wrap: true,
-        mode: 'compress'
+        mode: options.mode
     };
     return require('html2js')(code, opt);
 }

--- a/lib/processor/html2js-compiler.js
+++ b/lib/processor/html2js-compiler.js
@@ -107,9 +107,8 @@ function compileHtml2Js( code, options ) {
 
     var opt = {
         wrap: true,
-        mode: options.mode
+        mode: 'compress'
     };
-
     return require('html2js')(code, opt);
 }
 

--- a/lib/processor/source-combine.js
+++ b/lib/processor/source-combine.js
@@ -1,0 +1,78 @@
+var edp = require('edp-core');
+var path = require('path');
+var AbstractProcessor = require('./abstract');
+
+/**
+ * Output内容的清理处理器
+ *
+ * @constructor
+ * @param {Object} options
+ */
+function SourceProcessor(options) {
+    options = edp.util.mix({
+        files: ['*.html']
+    }, options);
+    AbstractProcessor.call(this, options);
+}
+SourceProcessor.prototype = new AbstractProcessor();
+
+/**
+ * @type {string}
+ */
+SourceProcessor.prototype.name = 'SourceProcessor';
+
+/**
+ * 构建处理
+ *
+ * @param {FileInfo} file 文件信息对象
+ * @param {ProcessContext} processContext 构建环境对象
+ * @param {Function} callback 处理完成回调函数
+ */
+SourceProcessor.prototype.process = function(file, processContext, callback) {
+    var data = file.data;
+    var reg = /\<(link|script).*?data\-replace(=[\"\'](.*?)[\"\'])?.*?\>.*?(\<\/(script)>)?/g;
+    var srcReg = /(src|href)=[\"\'](.*?)[\"\']/i;
+
+    var replaceMap = {
+        'script': '<script type="text/javascript">{::}</script>',
+        'link': '<style type="text/css">{::}</style>'
+    };
+
+    // 获取资源
+    function getContent(type, src) {
+        var result;
+        var mapRec = processContext.files || {};
+
+        if (mapRec[src]) {
+            result = mapRec[src];
+        } else {
+            for (var k in mapRec) {
+                var item = mapRec[k];
+                if (src == item.outputPath || src == item.path) {
+                    result = item;
+                    break;
+                }
+            }
+        }
+
+        if (result) {
+            console.log(result);
+            if (replaceMap[type]) {
+                return replaceMap[type].replace('{::}', result.data);
+            } else {
+                return result.data;
+            }
+        }
+    }
+
+    data = data.replace(reg, function(match, type, _, src) {
+        if (!src || /^(on|true|yes)$/i.test(src)) {
+            src = srcReg.exec(match)[2];
+        }
+        return getContent(type, src);
+    });
+    file.setData(data);
+    callback();
+};
+
+module.exports = exports = SourceProcessor;

--- a/lib/processor/source-combine.js
+++ b/lib/processor/source-combine.js
@@ -30,7 +30,7 @@ SourceProcessor.prototype.name = 'SourceProcessor';
  */
 SourceProcessor.prototype.process = function(file, processContext, callback) {
     var data = file.data;
-    var reg = /\<(link|script).*?data\-replace(=[\"\'](.*?)[\"\'])?.*?\>.*?(\<\/(script)>)?/g;
+    var reg = /\<(link|script|include).*?data\-combined(=[\"\'](.*?)[\"\'])?.*?\>.*?(\<\/(script|include)>)?/g;
     var srcReg = /(src|href)=[\"\'](.*?)[\"\']/i;
 
     var replaceMap = {

--- a/lib/processor/source-combine.js
+++ b/lib/processor/source-combine.js
@@ -56,7 +56,6 @@ SourceProcessor.prototype.process = function(file, processContext, callback) {
         }
 
         if (result) {
-            console.log(result);
             if (replaceMap[type]) {
                 return replaceMap[type].replace('{::}', result.data);
             } else {

--- a/lib/processor/source-combine.js
+++ b/lib/processor/source-combine.js
@@ -2,6 +2,10 @@ var edp = require('edp-core');
 var path = require('path');
 var AbstractProcessor = require('./abstract');
 
+var replaceMap = {
+    'script': '<script type="text/javascript">{::}</script>',
+    'link': '<style type="text/css">{::}</style>'
+};
 /**
  * Output内容的清理处理器
  *
@@ -14,6 +18,65 @@ function SourceProcessor(options) {
     }, options);
     AbstractProcessor.call(this, options);
 }
+
+/**
+ * 获取远程文件
+ *
+ * @constructor
+ * @param {Object} options
+ */
+function getRemoteUrl(url, callback) {
+    var type = /^https/.test(url) ? 'https' : 'http',
+        server = require(type);
+
+    server.get(url, function(res) {
+        var list = [];
+        if (res.statusCode === 404 || res.statusCode === 302) {
+            return callback(res.statusCode);
+        }
+        res.on('data', function(data) {
+            list.push(data);
+        });
+        res.on('end', function() {
+            callback(0, Buffer.concat(list) + '');
+        });
+    }).on('error', function() {
+        callback(500);
+    });
+};
+
+/**
+ * 文件映射中读取结果
+ *
+ * @constructor
+ * @param {Object} options
+ */
+function getFileFromContext(processContext, type, src) {
+    var result;
+
+    var mapRec = processContext.files || {};
+
+    if (mapRec[src]) {
+        result = mapRec[src];
+    } else {
+        for (var k in mapRec) {
+            var item = mapRec[k];
+            if (src == item.outputPath || src == item.path) {
+                result = item;
+                break;
+            }
+        }
+    }
+    if (result) {
+        if (replaceMap[type]) {
+            return replaceMap[type].replace('{::}', result.data);
+        } else {
+            return result.data;
+        }
+    }
+}
+
+
 SourceProcessor.prototype = new AbstractProcessor();
 
 /**
@@ -33,42 +96,11 @@ SourceProcessor.prototype.process = function(file, processContext, callback) {
     var reg = /\<(link|script|include).*?data\-combined(=[\"\'](.*?)[\"\'])?.*?\>.*?(\<\/(script|include)>)?/g;
     var srcReg = /(src|href)=[\"\'](.*?)[\"\']/i;
 
-    var replaceMap = {
-        'script': '<script type="text/javascript">{::}</script>',
-        'link': '<style type="text/css">{::}</style>'
-    };
-
-    // 获取资源
-    function getContent(type, src) {
-        var result;
-        var mapRec = processContext.files || {};
-
-        if (mapRec[src]) {
-            result = mapRec[src];
-        } else {
-            for (var k in mapRec) {
-                var item = mapRec[k];
-                if (src == item.outputPath || src == item.path) {
-                    result = item;
-                    break;
-                }
-            }
-        }
-
-        if (result) {
-            if (replaceMap[type]) {
-                return replaceMap[type].replace('{::}', result.data);
-            } else {
-                return result.data;
-            }
-        }
-    }
-
     data = data.replace(reg, function(match, type, _, src) {
         if (!src || /^(on|true|yes)$/i.test(src)) {
             src = srcReg.exec(match)[2];
         }
-        return getContent(type, src);
+        return getFileFromContext(processContext, type, src) || '';
     });
     file.setData(data);
     callback();


### PR DESCRIPTION
开发活动页面的时候，将CSS,JS单独文件引入，希望build的时候可以生成单HTML形式。

例如: 
```html
<link rel="stylesheet" type="text/css" href="src/style.css" data-combined="true">
```
 直接从processContext.files中替换过来:

```html
<style type="text/css">
.class {}
</style>
```

当然`data-combined`支持其他相对文件例如：

```html
<pre>
    <include data-combined="package.json"></include>
</pre>
```
