### PR TITLE
LessCompiler/StylusCompiler 支持自定义插件 ID

### DIFF
--- a/lib/processor/less-compiler.js
+++ b/lib/processor/less-compiler.js
@@ -47,6 +47,9 @@ LessCompiler.DEFAULT_OPTIONS = {
     // 可以配置 paths 等参数
     compileOptions: {},
 
+    // 自定义 JS 模块中引用 Less 文件的插件，用于编译完后替换资源名称
+    pluginIds: ['css'],
+
     // 自定义的 less 处理器
     less: null
 };
@@ -103,9 +106,10 @@ LessCompiler.prototype.afterAll = function (processContext) {
         return;
     }
 
+    var me = this;
     entryFiles.forEach(function (file) {
         var result = (file.extname === 'js')
-                     ? helper.replaceRequireResource(file.data, 'css', resourceReplacer)
+                     ? helper.replaceRequireResource(file.data, me.pluginIds, resourceReplacer)
                      : helper.replaceTagAttribute(file.data, 'link', 'href', valueReplacer);
 
         if (result) {

--- a/lib/processor/stylus-compiler.js
+++ b/lib/processor/stylus-compiler.js
@@ -34,6 +34,7 @@ StylusCompiler.DEFAULT_OPTIONS = {
         '*.tpl', '*.vm', '*.js'
     ],
     files: ['*.styl'],
+    pluginIds: ['css'],
     compileOptions: {}
 };
 
@@ -85,9 +86,10 @@ StylusCompiler.prototype.afterAll = function (processContext) {
         return;
     }
 
+    var me = this;
     entryFiles.forEach(function (file) {
         var result = (file.extname === 'js')
-                     ? helper.replaceRequireResource(file.data, 'css', resourceReplacer)
+                     ? helper.replaceRequireResource(file.data, me.pluginIds, resourceReplacer)
                      : helper.replaceTagAttribute(file.data, 'link', 'href', valueReplacer);
 
         if (result) {

--- a/test/babel-processor.spec.js
+++ b/test/babel-processor.spec.js
@@ -60,7 +60,7 @@ describe('babel-processor', function () {
 
         base.launchProcessors([p0, p1], processContext, function () {
             var fi = processContext.getFileByPath('src/hello.es6');
-            expect(fi.data).toEqual('define(["exports","babel-runtime/helpers/inherits","babel-runtime/helpers/class-call-check"],function(exports,e,t){(function(l){function n(){if(t["default"](this,n),null!=l)l.apply(this,arguments)}return e["default"](n,l),n.prototype.toString=function(){console.log("HelloWorld")},n})(Array)});');
+            expect(fi.data).toEqual('define(["exports","babel-runtime/helpers/inherits","babel-runtime/helpers/class-call-check"],function(exports,e,t){(function(n){function l(){t["default"](this,l),n.apply(this,arguments)}return e["default"](l,n),l.prototype.toString=function(){console.log("HelloWorld")},l})(Array)});');
             done();
         });
     });

--- a/test/issue-94.spec.js
+++ b/test/issue-94.spec.js
@@ -82,7 +82,7 @@ describe('issue-94', function () {
 
         base.launchProcessors([p0, p1, p1], processContext, function () {
             var fi = processContext.getFileByPath('src/issue-94.js');
-            expect(fi.data).toEqual("define([\n    'exports',\n    'bat-ria/tpl!startup/template',\n    'bat-ria/tpl!startup/template',\n    'er/View',\n    'babel-runtime/helpers/interop-require-default',\n    'no-such-plugin!./tpl/123.html'\n], function (exports, _batRiaTplTplListTplHtml, _batRiaTplTpl123Html, _erView, _babelRuntimeHelpersInteropRequireDefault, _noSuchPluginTpl123Html) {\n    var _View = (0, _babelRuntimeHelpersInteropRequireDefault['default'])(_erView);\n});");
+            expect(fi.data).toEqual("define([\n    'exports',\n    'bat-ria/tpl!startup/template',\n    'bat-ria/tpl!startup/template',\n    'er/View',\n    'babel-runtime/helpers/interop-require-default',\n    'no-such-plugin!./tpl/123.html'\n], function (exports, _batRiaTplTplListTplHtml, _batRiaTplTpl123Html, _erView, _babelRuntimeHelpersInteropRequireDefault, _noSuchPluginTpl123Html) {\n    var _View = _babelRuntimeHelpersInteropRequireDefault['default'](_erView);\n});");
             done();
         });
     });


### PR DESCRIPTION
让Less/Stylus编译支持自定义插件ID，以便在编译后替换资源路径时正确找到其他插件引入的Less/Stylus资源。

目前是写死 `'css'` 的，这样如果用 `lego/css!./Label.less` 来引入，打包完后 `.less` 不会替换成 `.css`。