### PR TITLE
支持 Babel 6 识别 `.babelrc`

### DIFF
--- a/lib/processor/babel-processor.js
+++ b/lib/processor/babel-processor.js
@@ -5,6 +5,7 @@
  */
 
 var util = require('util');
+var edp = require('edp-core');
 
 var AbstractProcessor = require('./abstract');
 
@@ -42,9 +43,19 @@ BabelProcessor.DEFAULT_OPTIONS = {
 BabelProcessor.prototype.process = function (file, processContext, callback) {
     var code = file.data;
 
+    var ast = edp.amd.getAst(code);
+    if (ast) {
+        var module = edp.amd.analyseModule(ast);
+        if (module) {
+            // 已经是 AMD 模块了，不需要转译
+            callback();
+            return;
+        }
+    }
+
     /* 支持读取 .babelrc，和 edp-webserver 逻辑保持一致 */
     var usedBabelOptions = {};
-    Object.keys(this.babelOptions || {}).forEach(function (key) { usedBabelOptions[key] = this.babelOptions[key]; });
+    Object.keys(this.compileOptions || {}).forEach(function (key) { usedBabelOptions[key] = this.compileOptions[key]; });
     usedBabelOptions.filename = file.path;
 
     var babelResult = this.babel.transform(code, usedBabelOptions);

--- a/lib/processor/babel-processor.js
+++ b/lib/processor/babel-processor.js
@@ -41,7 +41,13 @@ BabelProcessor.DEFAULT_OPTIONS = {
  */
 BabelProcessor.prototype.process = function (file, processContext, callback) {
     var code = file.data;
-    var babelResult = this.babel.transform(code, this.compileOptions);
+
+    /* 支持读取 .babelrc，和 edp-webserver 逻辑保持一致 */
+    var usedBabelOptions = {};
+    Object.keys(this.babelOptions || {}).forEach(function (key) { usedBabelOptions[key] = this.babelOptions[key]; });
+    usedBabelOptions.filename = file.path;
+
+    var babelResult = this.babel.transform(code, usedBabelOptions);
 
     file.setData(babelResult.code);
 


### PR DESCRIPTION
和 edp-webserver 的逻辑保持一致。

另外，用 `edp.amd` 提供的方法先识别一下是否已经有 AMD 模块，如有则跳过转译。这块 edp-webserver 目前的逻辑是查找 `define(` 这个字符串，可以考虑一起改一下（不过可能会导致慢一些）。