### PR TITLE
修复对output目录的过滤逻辑

### DIFF
--- a/cli/build.js
+++ b/cli/build.js
@@ -140,7 +140,7 @@ cli.main = function (args, opts) {
     // 如果output目录处于baseDir下，自动将output目录添加到exclude
     var outputRelative = path.relative(inputDir, outputDir);
     if (!/^\.\./.test(outputRelative)) {
-        exclude.push(outputRelative);
+        exclude.push(outputRelative + '/**');
     }
 
     // Processors的组合


### PR DESCRIPTION
假设我们使用`edp build --output static`，则上面修改处的代码原有逻辑会加一个`'static'`到`excludes`里去，而edp的排队逻辑是单纯的非路径的字符串时，是按关键字处理的，即`src/static`这种目录也一样会因此被过滤掉，所以需要改成`'static/**'`以避免这个情况