### PR TITLE
修改sourcemap打包JS文件空文件问题

### DIFF
--- a/lib/processor/js-compressor.js
+++ b/lib/processor/js-compressor.js
@@ -72,7 +72,7 @@ JsCompressor.prototype.process = function (file, processContext, callback) {
             }));
 
             processContext.addFile(new FileInfo({
-                data: (result.data || '').toString(),
+                data: (data.file.data || '').toString(),
                 extname: 'js',
                 path: edp.path.join(root, file.path),
                 fileEncoding: 'utf-8'


### PR DESCRIPTION
js-compressor下面result是个数组，result.data必然为空？