### PR TITLE
修改windows下压缩JS，kill子进程失败问题

### DIFF
--- a/lib/processor/js-compressor.js
+++ b/lib/processor/js-compressor.js
@@ -82,7 +82,11 @@ JsCompressor.prototype.process = function (file, processContext, callback) {
         file.setData(result[0]);
 
         // 杀掉子进程
-        child.kill('SIGHUP');
+        try {
+            child.kill('SIGHUP');
+        } catch (error) {
+            child.kill('SIGKILL');
+        }
 
         callback();
     });


### PR DESCRIPTION
JSCompressor处理器出现在windows中压缩中断，导致后续流程全部失效，其原因为打包一个js后，kill当前压缩进程失败报错。

增加try catch, 检测失败后再次换一种信号kill